### PR TITLE
chore(deps); update shlex to 1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ response = ["shlex"]
 [dependencies]
 fs-err = "2.9.0"
 os_str_bytes = "6.0"
-shlex = { version = "1.1.0", optional = true }
+shlex = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 clap = "4.4.18"


### PR DESCRIPTION
Updates dependency to the patch version of 1.3.0

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0006.html)